### PR TITLE
Correcting Mal capitalization. Was all caps.

### DIFF
--- a/Pymoe/Mal/__init__.py
+++ b/Pymoe/Mal/__init__.py
@@ -366,3 +366,4 @@ class Mal:
                 'planned': root.find('myinfo').find('user_plantoread').text,
                 'watching': root.find('myinfo').find('user_reading').text,
                 'days': root.find('myinfo').find('user_days_spent_watching').text}
+

--- a/Pymoe/__init__.py
+++ b/Pymoe/__init__.py
@@ -1,5 +1,5 @@
 from .Hummingbird import Hummingbird
 from .Bakatsuki import Bakatsuki
 from .VNDB import VNDB
-from .Mal import MAL
+from .Mal import Mal
 from .errors import *


### PR DESCRIPTION
Was writing a testing model, and this broke. When the MyAnimeList class changed from `MAL` to `Mal`, `Pymoe/__init__.py` wasn't updated.

I don't know why the whitespace edit happened, but it's just an extra newline on the end, so Imma leave it if it's all the same to you, too.
