### PR TITLE
Fixing kwarg issues with Anime

### DIFF
--- a/Pymoe/Mal/Objects.py
+++ b/Pymoe/Mal/Objects.py
@@ -31,6 +31,7 @@ class Anime:
 
         :param str aid: The Anime ID.
         :param int episode: Set the user's current episode.
+        :param int average: Set the average score.
         :param int score: Set the user's score.
         :param int status: Set the user's status for this anime. 1/watching,2/completed,3/onhold,4/dropped,6/plantowatch.
         :param str date_start: Set the date the user started this anime. Format should be MM-DD-YYYY.

--- a/Pymoe/Mal/__init__.py
+++ b/Pymoe/Mal/__init__.py
@@ -321,7 +321,7 @@ class Mal:
                 image=item.find('series_image').text,
                 status_anime=STATUS_INTS_ANIME[int(item.find('series_status').text)-1],
                 status=int(item.find('my_status').text),
-                rewatcing=int(item.find('my_rewatching').text) if item.find('my_rewatching').text else None,
+                rewatching=int(item.find('my_rewatching').text) if item.find('my_rewatching').text else None,
                 type=item.find('series_type').text,
                 tags=item.find('my_tags').text.split(',') if item.find('my_tags').text else []
             ))

--- a/Pymoe/Mal/__init__.py
+++ b/Pymoe/Mal/__init__.py
@@ -313,7 +313,7 @@ class Mal:
                 synonyms=syn,
                 episodes=item.find('series_episodes').text,
                 episode=item.find('my_watched_episodes').text,
-                user=item.find('my_score').text,
+                score=item.find('my_score').text,
                 anime_start=item.find('series_end').text,
                 anime_end=item.find('series_start').text,
                 date_start=item.find('my_start_date').text,


### PR DESCRIPTION
* The documentation for the `average` field was missing in the Anime object of Mal/Object.py
* More seriously, the `rewatching` field was misspelled when creating an Anime object, so the value of the expected field was always None.
* Similar problem with `score`, which was always `user`.