### PR TITLE
Fix date format when updating anime entries for MyAnimeList

### DIFF
--- a/Pymoe/Mal/Objects.py
+++ b/Pymoe/Mal/Objects.py
@@ -98,10 +98,10 @@ class Anime:
                     elif x == 'dates':
                         if self.dates.user.start:
                             start = ET.SubElement(root, 'date_start')
-                            start.text = self.format_date(self.dates.user.start)
+                            start.text = str(self.format_date(self.dates.user.start))
                         if self.dates.user.end:
                             end = ET.SubElement(root, 'date_finish')
-                            end.text = self.format_date(self.dates.user.end)
+                            end.text = str(self.format_date(self.dates.user.end))
                     elif x == 'storage':
                         if self.storage.type:
                             stype = ET.SubElement(root, 'storage_type')
@@ -201,11 +201,6 @@ class Manga:
         self.xml_tags = ['id', 'chapters', 'volumes', 'scores', 'status', 'dates', 'storage', 'reread', 'flags',
                          'priority', 'comments', 'tags', 'scan_group']
 
-    @staticmethod
-    def format_date(data):
-        date_list = data.split("-")
-        return "{}{}{}".format(date_list[1], date_list[2], date_list[0])
-
     def to_xml(self):
         root = ET.Element("entry")
         for x in self.xml_tags:
@@ -230,10 +225,10 @@ class Manga:
                     elif x == 'dates':
                         if self.dates.user.start:
                             start = ET.SubElement(root, 'date_start')
-                            start.text = str(format_date(self.dates.user.start))
+                            start.text = str(self.format_date(self.dates.user.start))
                         if self.dates.user.end:
                             end = ET.SubElement(root, 'date_finish')
-                            end.text = str(format_date(self.dates.user.end))
+                            end.text = str(self.format_date(self.dates.user.end))
                     elif x == 'storage':
                         if self.storage.type:
                             stype = ET.SubElement(root, 'storage_type')

--- a/Pymoe/Mal/Objects.py
+++ b/Pymoe/Mal/Objects.py
@@ -69,6 +69,11 @@ class Anime:
         self.xml_tags = ['episodes', 'scores', 'status', 'dates', 'storage', 'rewatched', 'flags', 'priority',
                          'comments', 'tags', 'fansub_group']
 
+    @staticmethod
+    def format_date(data):
+        date_list = data.split("-")
+        return "{}{}{}".format(date_list[1], date_list[2], date_list[0])
+
     def to_xml(self):
         """
         Convert data to XML String.
@@ -93,10 +98,10 @@ class Anime:
                     elif x == 'dates':
                         if self.dates.user.start:
                             start = ET.SubElement(root, 'date_start')
-                            start.text = self.dates.user.start
+                            start.text = self.format_date(self.dates.user.start)
                         if self.dates.user.end:
                             end = ET.SubElement(root, 'date_finish')
-                            end.text = self.dates.user.end
+                            end.text = self.format_date(self.dates.user.end)
                     elif x == 'storage':
                         if self.storage.type:
                             stype = ET.SubElement(root, 'storage_type')
@@ -196,6 +201,11 @@ class Manga:
         self.xml_tags = ['id', 'chapters', 'volumes', 'scores', 'status', 'dates', 'storage', 'reread', 'flags',
                          'priority', 'comments', 'tags', 'scan_group']
 
+    @staticmethod
+    def format_date(data):
+        date_list = data.split("-")
+        return "{}{}{}".format(date_list[1], date_list[2], date_list[0])
+
     def to_xml(self):
         root = ET.Element("entry")
         for x in self.xml_tags:
@@ -220,10 +230,10 @@ class Manga:
                     elif x == 'dates':
                         if self.dates.user.start:
                             start = ET.SubElement(root, 'date_start')
-                            start.text = str(self.dates.user.start)
+                            start.text = str(format_date(self.dates.user.start))
                         if self.dates.user.end:
                             end = ET.SubElement(root, 'date_finish')
-                            end.text = str(self.dates.user.end)
+                            end.text = str(format_date(self.dates.user.end))
                     elif x == 'storage':
                         if self.storage.type:
                             stype = ET.SubElement(root, 'storage_type')


### PR DESCRIPTION
Fixes #17 
[The MAL API expects a MMDDYYYY format when updating anime](https://myanimelist.net/modules.php?go=api#animevalues). Unfortunately for us, it provides YYYY-MM-DD when retrieving from https://myanimelist.net/malappinfo.php. This pull request fixes this issue by adding an intermediate function that adjusts the date format before it is sent to https://myanimelist.net/api/animelist/update/.