### PR TITLE
Fix Anilist manga search (was type: ANIME)

### DIFF
--- a/Pymoe/Anilist/search.py
+++ b/Pymoe/Anilist/search.py
@@ -127,7 +127,7 @@ class ASearch:
                         lastPage
                         hasNextPage
                     }
-                    media (search: $query, type: ANIME) {
+                    media (search: $query, type: MANGA) {
                         id
                         title {
                             romaji
@@ -138,7 +138,8 @@ class ASearch:
                         }
                         averageScore
                         popularity
-                        episodes
+                        chapters
+                        volumes
                         season
                         hashtag
                         isAdult


### PR DESCRIPTION
The search for manga was using the same query_string as for anime.
query_string is now fixed.